### PR TITLE
Use of Host macros and iDrac8

### DIFF
--- a/dell/README.md
+++ b/dell/README.md
@@ -2,4 +2,4 @@
 
 Here you'll find a collection of templates and scripts for monitoring Dell equipaments.
 
-* [iDRAC 7 via SNMP](./idrac)
+* [iDRAC 7 and 8 via SNMP](./idrac)

--- a/dell/idrac/Template_Dell_iDRAC_SNMPv2.zbx.xml
+++ b/dell/idrac/Template_Dell_iDRAC_SNMPv2.zbx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>2.0</version>
-    <date>2015-09-14T08:43:40Z</date>
+    <date>2015-09-15T13:59:56Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -1904,7 +1904,7 @@
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.50.1.8.1</snmp_oid>
                     <key>MemoryEnum</key>
-                    <delay>86400</delay>
+                    <delay>43200</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -2766,7 +2766,7 @@
                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.32.1.7.1</snmp_oid>
                     <key>ProcEnum</key>
-                    <delay>86400</delay>
+                    <delay>43200</delay>
                     <status>0</status>
                     <allowed_hosts/>
                     <snmpv3_contextname/>
@@ -2841,7 +2841,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template Dell iDrac SNMPV2:ProcStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;3</expression>
+                            <expression>({Template Dell iDrac SNMPV2:ProcStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;3 and {Template Dell iDrac SNMPV2:ProcStatus.[{#SNMPINDEX}].last(0)}&lt;&gt;2) or ({Template Dell iDrac SNMPV2:ProcStatus.[{#SNMPINDEX}].last(86400)}&lt;&gt;2 and {Template Dell iDrac SNMPV2:ProcStatus.[{#SNMPINDEX}].last(0)}=2)</expression>
                             <name>Error on Processor {#SNMPINDEX}</name>
                             <url/>
                             <status>0</status>
@@ -3431,7 +3431,7 @@ and&#13;
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{Template Dell iDrac SNMPV2:GlobalSystemPowerState.last(0)}&lt;&gt;4</expression>
+            <expression>{Template Dell iDrac SNMPV2:GlobalSystemPowerState.last(0)}&lt;&gt;4 and {Template Dell iDrac SNMPV2:GlobalSystemPowerState.last(0)}&lt;&gt;0</expression>
             <name>System is not online</name>
             <url/>
             <status>0</status>

--- a/dell/idrac/Template_Dell_iDRAC_SNMPv2.zbx.xml
+++ b/dell/idrac/Template_Dell_iDRAC_SNMPv2.zbx.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>2.0</version>
-    <date>2014-10-20T18:04:59Z</date>
+    <date>2015-09-14T08:43:40Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -47,7 +47,7 @@
                 <item>
                     <name>BIOS Date</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.300.50.1.7.1.1</snmp_oid>
                     <key>BiosDate</key>
@@ -90,7 +90,7 @@
                 <item>
                     <name>BIOS Version</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.300.50.1.8.1.1</snmp_oid>
                     <key>BiosVersion</key>
@@ -133,7 +133,7 @@
                 <item>
                     <name>CMOS Battery Status</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.600.50.1.5.1.1</snmp_oid>
                     <key>CMOSBatteryStatus</key>
@@ -178,7 +178,7 @@
                 <item>
                     <name>DRAC Access URL</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.2.1.1.7.0</snmp_oid>
                     <key>idrac_acessurl</key>
@@ -221,7 +221,7 @@
                 <item>
                     <name>DRAC Firmware version</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.2.1.1.5.0</snmp_oid>
                     <key>idrac_firmwareversion</key>
@@ -264,7 +264,7 @@
                 <item>
                     <name>DRAC version</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.2.1.1.2.0</snmp_oid>
                     <key>idrac_version</key>
@@ -307,7 +307,7 @@
                 <item>
                     <name>Overall System LCD Status</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.2.2.0</snmp_oid>
                     <key>GlobalSystemLCDStatus</key>
@@ -352,7 +352,7 @@
                 <item>
                     <name>Overall System Power State</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.2.4.0</snmp_oid>
                     <key>GlobalSystemPowerState</key>
@@ -397,7 +397,7 @@
                 <item>
                     <name>Overall System Rollup Status</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.2.1.0</snmp_oid>
                     <key>GlobalSystemRollupStatus</key>
@@ -442,7 +442,7 @@
                 <item>
                     <name>Overall System Status</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.2.2.1.0</snmp_oid>
                     <key>GlobalSystemStatus</key>
@@ -487,7 +487,7 @@
                 <item>
                     <name>Overall System Storage Status</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.2.3.0</snmp_oid>
                     <key>GlobalSystemStorageStatus</key>
@@ -532,7 +532,7 @@
                 <item>
                     <name>Power Usage Minimum Idle Power</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.600.60.1.15.1.1</snmp_oid>
                     <key>PowerUsageMinIdle</key>
@@ -575,7 +575,7 @@
                 <item>
                     <name>Power Usage Sensor Status</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.600.60.1.5.1.1</snmp_oid>
                     <key>PowerUsageSensorStatus</key>
@@ -620,7 +620,7 @@
                 <item>
                     <name>RAID Controller : Firmware Version</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.130.1.1.8.1</snmp_oid>
                     <key>RAIDControllerFirmware</key>
@@ -663,7 +663,7 @@
                 <item>
                     <name>RAID Controller : Name</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.130.1.1.2.1</snmp_oid>
                     <key>RAIDControllerName</key>
@@ -706,7 +706,7 @@
                 <item>
                     <name>RAID Controller : Status</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.130.1.1.37.1</snmp_oid>
                     <key>RAIDControllerStatus</key>
@@ -751,7 +751,7 @@
                 <item>
                     <name>System Asset Tag</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.2.1.1.11.0</snmp_oid>
                     <key>idrac_assettag</key>
@@ -794,7 +794,7 @@
                 <item>
                     <name>System BIOS Status</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.300.50.1.5.1.1</snmp_oid>
                     <key>SystemBiosStatus</key>
@@ -839,7 +839,7 @@
                 <item>
                     <name>System Express Service Code</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.1.3.3.0</snmp_oid>
                     <key>idrac_esc</key>
@@ -882,7 +882,7 @@
                 <item>
                     <name>System Model</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.1.3.12.0</snmp_oid>
                     <key>idrac_SystemModel</key>
@@ -925,7 +925,7 @@
                 <item>
                     <name>Voltage Status Combined</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <multiplier>0</multiplier>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.200.10.1.12.1</snmp_oid>
                     <key>VoltageStatusCombined</key>
@@ -972,7 +972,7 @@
                 <discovery_rule>
                     <name>Disk Enumeration</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.2</snmp_oid>
                     <key>DiskEnumeration</key>
                     <delay>7200</delay>
@@ -1005,7 +1005,7 @@
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} : Disk Size</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>1</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.11.{#SNMPINDEX}</snmp_oid>
                             <key>DiskSize.[{#SNMPINDEX}]</key>
@@ -1048,7 +1048,7 @@
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} : Disk State</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.4.{#SNMPINDEX}</snmp_oid>
                             <key>DiskState.[{#SNMPINDEX}]</key>
@@ -1093,7 +1093,7 @@
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} : Disk Status</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.24.{#SNMPINDEX}</snmp_oid>
                             <key>DiskStatus.[{#SNMPINDEX}]</key>
@@ -1138,7 +1138,7 @@
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} : Manufacture Day</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.32.{#SNMPINDEX}</snmp_oid>
                             <key>DiskManufactureDay.[{#SNMPINDEX}]</key>
@@ -1181,7 +1181,7 @@
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} : Manufacturer</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.3.{#SNMPINDEX}</snmp_oid>
                             <key>DiskManufacturer.[{#SNMPINDEX}]</key>
@@ -1224,7 +1224,7 @@
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} : Manufacture Week</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.33.{#SNMPINDEX}</snmp_oid>
                             <key>DiskManufactureWeek.[{#SNMPINDEX}]</key>
@@ -1267,7 +1267,7 @@
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} : Manufacture Year</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.34.{#SNMPINDEX}</snmp_oid>
                             <key>DiskManufactureYear.[{#SNMPINDEX}]</key>
@@ -1310,7 +1310,7 @@
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} : Model Number</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.6.{#SNMPINDEX}</snmp_oid>
                             <key>DiskModel.[{#SNMPINDEX}]</key>
@@ -1353,7 +1353,7 @@
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} : Name</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.55.{#SNMPINDEX}</snmp_oid>
                             <key>DiskName.[{#SNMPINDEX}]</key>
@@ -1396,7 +1396,7 @@
                         <item_prototype>
                             <name>Disk {#SNMPINDEX} : Serial Number</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.7.{#SNMPINDEX}</snmp_oid>
                             <key>DiskSerialNo.[{#SNMPINDEX}]</key>
@@ -1454,7 +1454,7 @@
                 <discovery_rule>
                     <name>Disk Volume Enumeration</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.140.1.1.1</snmp_oid>
                     <key>VolumeEnum</key>
                     <delay>7200</delay>
@@ -1487,7 +1487,7 @@
                         <item_prototype>
                             <name>Volume {#SNMPINDEX} : Name</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.140.1.1.36.{#SNMPINDEX}</snmp_oid>
                             <key>VolumeName.[{#SNMPINDEX}]</key>
@@ -1530,7 +1530,7 @@
                         <item_prototype>
                             <name>Volume {#SNMPINDEX} : Size</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>1</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.140.1.1.6.{#SNMPINDEX}</snmp_oid>
                             <key>VolumeSize.[{#SNMPINDEX}]</key>
@@ -1573,7 +1573,7 @@
                         <item_prototype>
                             <name>Volume {#SNMPINDEX} : State</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.140.1.1.13.{#SNMPINDEX}</snmp_oid>
                             <key>VolumeState.[{#SNMPINDEX}]</key>
@@ -1618,7 +1618,7 @@
                         <item_prototype>
                             <name>Volume {#SNMPINDEX} : Status</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.140.1.1.20.{#SNMPINDEX}</snmp_oid>
                             <key>VolumeStatus.[{#SNMPINDEX}]</key>
@@ -1663,7 +1663,7 @@
                         <item_prototype>
                             <name>Volume {#SNMPINDEX} : Virtual Disk State</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.5.1.20.140.1.1.4.{#SNMPINDEX}</snmp_oid>
                             <key>VolumeDiskState.[{#SNMPINDEX}]</key>
@@ -1732,7 +1732,7 @@
                 <discovery_rule>
                     <name>Fan Enumeration</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.700.12.1.8.1</snmp_oid>
                     <key>FanEnumeration</key>
                     <delay>7200</delay>
@@ -1765,7 +1765,7 @@
                         <item_prototype>
                             <name>Fan {#SNMPVALUE} Speed</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.700.12.1.6.1.{#SNMPINDEX}</snmp_oid>
                             <key>FanSpeed.[{#SNMPINDEX}]</key>
@@ -1808,7 +1808,7 @@
                         <item_prototype>
                             <name>Fan {#SNMPVALUE} Status</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.700.12.1.5.1.{#SNMPINDEX}</snmp_oid>
                             <key>FanStatus.[{#SNMPINDEX}]</key>
@@ -1901,7 +1901,7 @@
                 <discovery_rule>
                     <name>Memory Enumeration</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.50.1.8.1</snmp_oid>
                     <key>MemoryEnum</key>
                     <delay>86400</delay>
@@ -1934,7 +1934,7 @@
                         <item_prototype>
                             <name>Memory Slot {#SNMPVALUE} Manufacturer</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.50.1.21.1.{#SNMPINDEX}</snmp_oid>
                             <key>MemManufacturer[{#SNMPINDEX}]</key>
@@ -1977,7 +1977,7 @@
                         <item_prototype>
                             <name>Memory Slot {#SNMPVALUE} Part Number</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.50.1.22.1.{#SNMPINDEX}</snmp_oid>
                             <key>MemPartlNo.[{#SNMPINDEX}]</key>
@@ -2020,7 +2020,7 @@
                         <item_prototype>
                             <name>Memory Slot {#SNMPVALUE} Serial Number</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.50.1.23.1.{#SNMPINDEX}</snmp_oid>
                             <key>MemSerialNo.[{#SNMPINDEX}]</key>
@@ -2063,7 +2063,7 @@
                         <item_prototype>
                             <name>Memory Slot {#SNMPVALUE} Size</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>1</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.50.1.14.1.{#SNMPINDEX}</snmp_oid>
                             <key>MemSize.[{#SNMPINDEX}]</key>
@@ -2106,7 +2106,7 @@
                         <item_prototype>
                             <name>Memory Slot {#SNMPVALUE} Speed</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.50.1.15.1.{#SNMPINDEX}</snmp_oid>
                             <key>MemSpeed.[{#SNMPINDEX}]</key>
@@ -2149,7 +2149,7 @@
                         <item_prototype>
                             <name>Memory Slot {#SNMPVALUE} Status</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.50.1.5.1.{#SNMPINDEX}</snmp_oid>
                             <key>MemStatus.[{#SNMPINDEX}]</key>
@@ -2209,7 +2209,7 @@
                 <discovery_rule>
                     <name>Network Enumeration</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.90.1.2.1</snmp_oid>
                     <key>NetworkEnum</key>
                     <delay>7200</delay>
@@ -2242,7 +2242,7 @@
                         <item_prototype>
                             <name>NIC {#SNMPINDEX} : Connection Status</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.90.1.4.1.{#SNMPINDEX}</snmp_oid>
                             <key>NetConnStatus.[{#SNMPINDEX}]</key>
@@ -2287,7 +2287,7 @@
                         <item_prototype>
                             <name>NIC {#SNMPINDEX} : MAC Address</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.90.1.15.1.{#SNMPINDEX}</snmp_oid>
                             <key>NetMAC.[{#SNMPINDEX}]</key>
@@ -2330,7 +2330,7 @@
                         <item_prototype>
                             <name>NIC {#SNMPINDEX} : Name</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.90.1.6.1.{#SNMPINDEX}</snmp_oid>
                             <key>NetName.[{#SNMPINDEX}]</key>
@@ -2373,7 +2373,7 @@
                         <item_prototype>
                             <name>NIC {#SNMPINDEX} : Slot</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.90.1.30.1.{#SNMPINDEX}</snmp_oid>
                             <key>NetSlot.[{#SNMPINDEX}]</key>
@@ -2416,7 +2416,7 @@
                         <item_prototype>
                             <name>NIC {#SNMPINDEX} : Status</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.90.1.3.1.{#SNMPINDEX}</snmp_oid>
                             <key>NetStatus.[{#SNMPINDEX}]</key>
@@ -2485,7 +2485,7 @@
                 <discovery_rule>
                     <name>Power Supply Enumeration</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.600.12.1.1.1</snmp_oid>
                     <key>PowerSupplies</key>
                     <delay>7200</delay>
@@ -2518,7 +2518,7 @@
                         <item_prototype>
                             <name>Power Supply {#SNMPINDEX} Input Voltage</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.600.12.1.9.1.{#SNMPINDEX}</snmp_oid>
                             <key>PowerSupplyInputVoltage.[{#SNMPINDEX}]</key>
@@ -2561,7 +2561,7 @@
                         <item_prototype>
                             <name>Power Supply {#SNMPINDEX} Maximum Power</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>1</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.600.12.1.6.1.{#SNMPINDEX}</snmp_oid>
                             <key>PowerSupplyMaxPower.[{#SNMPINDEX}]</key>
@@ -2604,7 +2604,7 @@
                         <item_prototype>
                             <name>Power Supply {#SNMPINDEX} Sensor State</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.600.12.1.11.1.{#SNMPINDEX}</snmp_oid>
                             <key>PowerSupplySensorState.[{#SNMPINDEX}]</key>
@@ -2649,7 +2649,7 @@
                         <item_prototype>
                             <name>Power Supply {#SNMPINDEX} State Settings</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.600.12.1.4.1.{#SNMPINDEX}</snmp_oid>
                             <key>PowerSupplyStateSettings.[{#SNMPINDEX}]</key>
@@ -2694,7 +2694,7 @@
                         <item_prototype>
                             <name>Power Supply {#SNMPINDEX} Status</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.600.12.1.5.1.{#SNMPINDEX}</snmp_oid>
                             <key>PowerSupplyStatus.[{#SNMPINDEX}]</key>
@@ -2763,7 +2763,7 @@
                 <discovery_rule>
                     <name>Processor Enumeration</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.32.1.7.1</snmp_oid>
                     <key>ProcEnum</key>
                     <delay>86400</delay>
@@ -2796,7 +2796,7 @@
                         <item_prototype>
                             <name>Processor {#SNMPINDEX} Status</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.1100.32.1.5.1.{#SNMPINDEX}</snmp_oid>
                             <key>ProcStatus.[{#SNMPINDEX}]</key>
@@ -2856,7 +2856,7 @@
                 <discovery_rule>
                     <name>Temperature Enumeration</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.700.20.1.8.1</snmp_oid>
                     <key>TempEnum</key>
                     <delay>7200</delay>
@@ -2889,7 +2889,7 @@
                         <item_prototype>
                             <name>Temperature Sensor {#SNMPVALUE} Critical Low-Limit</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>1</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.700.20.1.13.1.{#SNMPINDEX}</snmp_oid>
                             <key>TempCritLowLimit.[{#SNMPINDEX}]</key>
@@ -2932,7 +2932,7 @@
                         <item_prototype>
                             <name>Temperature Sensor {#SNMPVALUE} Critical Up-Limit</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>1</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.700.20.1.10.1.{#SNMPINDEX}</snmp_oid>
                             <key>TempCritUpLimit.[{#SNMPINDEX}]</key>
@@ -2975,7 +2975,7 @@
                         <item_prototype>
                             <name>Temperature Sensor {#SNMPVALUE} Status</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.700.20.1.5.1.{#SNMPINDEX}</snmp_oid>
                             <key>TempStatus.[{#SNMPINDEX}]</key>
@@ -3020,7 +3020,7 @@
                         <item_prototype>
                             <name>Temperature Sensor {#SNMPVALUE} Value</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>1</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.700.20.1.6.1.{#SNMPINDEX}</snmp_oid>
                             <key>TempValue.[{#SNMPINDEX}]</key>
@@ -3065,7 +3065,7 @@
                         <item_prototype>
                             <name>Temperature Sensor {#SNMPVALUE} Warning Low-Limit</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>1</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.700.20.1.12.1.{#SNMPINDEX}</snmp_oid>
                             <key>TempWarnLowLimit.[{#SNMPINDEX}]</key>
@@ -3108,7 +3108,7 @@
                         <item_prototype>
                             <name>Temperature Sensor {#SNMPVALUE} Warning Up-Limit</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>1</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.700.20.1.11.1.{#SNMPINDEX}</snmp_oid>
                             <key>TempWarnUpLimit.[{#SNMPINDEX}]</key>
@@ -3243,7 +3243,7 @@ and&#13;
                 <discovery_rule>
                     <name>Voltage Table Enumeration</name>
                     <type>4</type>
-                    <snmp_community>public</snmp_community>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                     <snmp_oid>1.3.6.1.4.1.674.10892.5.4.600.20.1.8.1</snmp_oid>
                     <key>VoltageTable</key>
                     <delay>7200</delay>
@@ -3276,7 +3276,7 @@ and&#13;
                         <item_prototype>
                             <name>Voltage : {#SNMPVALUE} Status</name>
                             <type>4</type>
-                            <snmp_community>public</snmp_community>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                             <multiplier>0</multiplier>
                             <snmp_oid>1.3.6.1.4.1.674.10892.5.4.600.20.1.5.1.{#SNMPINDEX}</snmp_oid>
                             <key>VoltageStatus.[{#SNMPINDEX}]</key>
@@ -3351,21 +3351,21 @@ and&#13;
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{Template Dell iDrac SNMPV2:GlobalSystemRollupStatus.last(0)}&lt;&gt;3</expression>
-            <name>Overall System Rollup Status Error</name>
-            <url/>
-            <status>0</status>
-            <priority>2</priority>
-            <description/>
-            <type>0</type>
-            <dependencies/>
-        </trigger>
-        <trigger>
             <expression>{Template Dell iDrac SNMPV2:GlobalSystemRollupStatus.last(0)}&gt;4</expression>
             <name>Overall System Rollup Status Error</name>
             <url/>
             <status>0</status>
             <priority>5</priority>
+            <description/>
+            <type>0</type>
+            <dependencies/>
+        </trigger>
+        <trigger>
+            <expression>{Template Dell iDrac SNMPV2:GlobalSystemRollupStatus.last(0)}&lt;&gt;3</expression>
+            <name>Overall System Rollup Status Error</name>
+            <url/>
+            <status>0</status>
+            <priority>2</priority>
             <description/>
             <type>0</type>
             <dependencies/>
@@ -3411,21 +3411,21 @@ and&#13;
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{Template Dell iDrac SNMPV2:GlobalSystemStorageStatus.last(0)}&lt;&gt;3</expression>
-            <name>Storage System Status Error</name>
-            <url/>
-            <status>0</status>
-            <priority>2</priority>
-            <description/>
-            <type>0</type>
-            <dependencies/>
-        </trigger>
-        <trigger>
             <expression>{Template Dell iDrac SNMPV2:GlobalSystemStorageStatus.last(0)}&gt;4</expression>
             <name>Storage System Status Error</name>
             <url/>
             <status>0</status>
             <priority>5</priority>
+            <description/>
+            <type>0</type>
+            <dependencies/>
+        </trigger>
+        <trigger>
+            <expression>{Template Dell iDrac SNMPV2:GlobalSystemStorageStatus.last(0)}&lt;&gt;3</expression>
+            <name>Storage System Status Error</name>
+            <url/>
+            <status>0</status>
+            <priority>2</priority>
             <description/>
             <type>0</type>
             <dependencies/>


### PR DESCRIPTION
Hi,
I exported hardcoded SNMP community "public" to Host macro (meaning {$SNMP_COMMUNITY}) - This way, you can specify SNMP community per host which enabled you to set higher security for your network. When  {$SNMP_COMMUNITY} is not set, zabbix uses "public" by default.

The other thing is, Iam using this template with iDrac8 on server R530 and it works flawlessly, so I changed the caption.

Thanks for your hard work!
